### PR TITLE
RELEASE: October 5 release for rebranded Workload Factory.

### DIFF
--- a/_index.yml
+++ b/_index.yml
@@ -1,6 +1,6 @@
 indexpage:
-  title: BlueXP workload factory for Builders documentation
-  lead: Create and manage software development projects on top of FSx for ONTAP file system storage in BlueXP Workload factory.
+  title: NetApp workload factory for Builders documentation
+  lead: Create and manage software development projects on top of FSx for ONTAP file system storage in NetApp workload factory.
   tiles: 
     - title: Get started
       links:

--- a/_index.yml
+++ b/_index.yml
@@ -26,9 +26,9 @@ indexpage:
           url: /get-help-builders.html
     - title: Blogs & community
       links:
-        - title: NetApp Community 
-          url: https://community.netapp.com/t5/BlueXP-and-Services/ct-p/CDS
-        - title: BlueXP blogs 
-          url: https://bluexp.netapp.com/blog
-        - title: Cloud webinars 
-          url: https://bluexp.netapp.com/events   
+        - title: NetApp Console
+          url: https://www.netapp.com/console
+        - title: NetApp Data Services
+          url: https://www.netapp.com/data-services/
+        - title: NetApp Community
+          url: https://community.netapp.com/  

--- a/_index.yml
+++ b/_index.yml
@@ -1,6 +1,6 @@
 indexpage:
-  title: NetApp workload factory for Builders documentation
-  lead: Create and manage software development projects on top of FSx for ONTAP file system storage in NetApp workload factory.
+  title: NetApp Workload Factory for Builders documentation
+  lead: Create and manage software development projects on top of FSx for ONTAP file system storage in NetApp Workload Factory.
   tiles: 
     - title: Get started
       links:

--- a/_whatsnew/2024-12-01.adoc
+++ b/_whatsnew/2024-12-01.adoc
@@ -1,4 +1,4 @@
 === Builders workload initial release  
-BlueXP workload factory for Builders simplifies software version consumption and access, eliminating the need for custom tools or scripts. It enables you to consume software versions as instant clones integrated with Perforce Helix Core as a convenient workspace for your development processes, saving time and resources.
+BlueXP Workload Factory for Builders simplifies software version consumption and access, eliminating the need for custom tools or scripts. It enables you to consume software versions as instant clones integrated with Perforce Helix Core as a convenient workspace for your development processes, saving time and resources.
 
 The initial release includes the capability to manage projects and workspaces, and automate actions with Codebox. You can also integrate Builders with Perforce Helix Core, so that you can manage different versions of each project and switch between them quickly.

--- a/_whatsnew/2025-05-04.adoc
+++ b/_whatsnew/2025-05-04.adoc
@@ -1,4 +1,4 @@
 === Updated permissions terminology
-The workload factory user interface and documentation now use "read-only" to refer to read permissions and "read/write" to refer to automate permissions.
+The Workload Factory user interface and documentation now use "read-only" to refer to read permissions and "read/write" to refer to automate permissions.
 
 // Use absolute links in these files

--- a/_whatsnew/2025-06-16.adoc
+++ b/_whatsnew/2025-06-16.adoc
@@ -1,6 +1,6 @@
 === Clone support
-You can now clone a project in BlueXP workload factory for Builders. When you clone a project, Builders creates a new project from a snapshot, with the same configuration as the original. Cloning is useful for quickly creating similar projects or for testing purposes. You can mount the new project clone by following the instructions in Builders.
+You can now clone a project in BlueXP Workload Factory for Builders. When you clone a project, Builders creates a new project from a snapshot, with the same configuration as the original. Cloning is useful for quickly creating similar projects or for testing purposes. You can mount the new project clone by following the instructions in Builders.
 
-https://docs.netapp.com/us-en/workload-builders/version-projects.html[Manage versions of BlueXP workload factory for Builders projects]
+https://docs.netapp.com/us-en/workload-builders/version-projects.html[Manage versions of BlueXP Workload Factory for Builders projects]
 
 // Use absolute links in these files

--- a/_whatsnew/2025-10-05.adoc
+++ b/_whatsnew/2025-10-05.adoc
@@ -1,0 +1,5 @@
+=== BlueXP workload factory now NetApp Workload Factory
+ 
+BlueXP has been renamed and redesigned to better reflect the role it has in managing your data infrastructure. As a result, BlueXP workload factory has been renamed to NetApp Workload Factory.
+
+// Use absolute links in these files

--- a/automate-codebox.adoc
+++ b/automate-codebox.adoc
@@ -9,6 +9,6 @@ summary: You can automate host deployment, database creation, and more with Code
 :imagesdir: ./media/
 
 [.lead]
-You can automate project creation and data protection operations with Codebox. Codebox is an infrastructure as code (IaC) co-pilot that helps you generate code to execute any operations supported by workload factory. 
+You can automate project creation and data protection operations with Codebox. Codebox is an infrastructure as code (IaC) co-pilot that helps you generate code to execute any operations supported by Workload Factory. 
 
 Learn more about link:https://docs.netapp.com/us-en/workload-setup-admin/codebox-automation.html[Codebox automation^] and how to use it.

--- a/create-workspaces.adoc
+++ b/create-workspaces.adoc
@@ -23,6 +23,7 @@ Ensure you have integrated Builders with the Perforce Helix Visual Client. See l
 +
 The Workload Factory login screen appears within the Perforce UI.
 . Log in to Workload Factory using one of the link:https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
+. In the Builders workloads tile, select *Create project*.
 . Select *Create workspace*. 
 . On the Create a workspace project page, provide the following:
 .. Select a snapshot to use as a basis for the workspace.

--- a/create-workspaces.adoc
+++ b/create-workspaces.adoc
@@ -2,14 +2,14 @@
 sidebar: sidebar
 permalink: create-workspaces.html
 keywords: manage, workspace, snapshot, project 
-summary: A workspace in NetApp workload factory for Builders is a Perforce representation of a project that is based off of a project snapshot. You can create workspaces as part of a Builders project.
+summary: A workspace in NetApp Workload Factory for Builders is a Perforce representation of a project that is based off of a project snapshot. You can create workspaces as part of a Builders project.
 ---
 = Create a Builders workspace
 :icons: font
 :imagesdir: ./media/
 
 [.lead]
-A workspace in NetApp workload factory for Builders is a Perforce representation of a project at a specific moment in time. Workspaces are created using a project snapshot as a basis. You can create new workspaces within a Builders project. You can create workspaces from the Perforce UI.
+A workspace in NetApp Workload Factory for Builders is a Perforce representation of a project at a specific moment in time. Workspaces are created using a project snapshot as a basis. You can create new workspaces within a Builders project. You can create workspaces from the Perforce UI.
 
 //== Create a workspace
 //You can create a new workspace from a snapshot of a project.
@@ -21,8 +21,8 @@ Ensure you have integrated Builders with the Perforce Helix Visual Client. See l
 . Log in to Perforce.
 . In the Perforce menu, select *View* > *WF*.
 +
-The workload factory login screen appears within the Perforce UI.
-. Log in to workload factory using one of the link:https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
+The Workload Factory login screen appears within the Perforce UI.
+. Log in to Workload Factory using one of the link:https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
 . Select *Create workspace*. 
 . On the Create a workspace project page, provide the following:
 .. Select a snapshot to use as a basis for the workspace.

--- a/create-workspaces.adoc
+++ b/create-workspaces.adoc
@@ -2,14 +2,14 @@
 sidebar: sidebar
 permalink: create-workspaces.html
 keywords: manage, workspace, snapshot, project 
-summary: A workspace in BlueXP workload factory for Builders is a Perforce representation of a project that is based off of a project snapshot. You can create workspaces as part of a Builders project.
+summary: A workspace in NetApp workload factory for Builders is a Perforce representation of a project that is based off of a project snapshot. You can create workspaces as part of a Builders project.
 ---
 = Create a Builders workspace
 :icons: font
 :imagesdir: ./media/
 
 [.lead]
-A workspace in BlueXP workload factory for Builders is a Perforce representation of a project at a specific moment in time. Workspaces are created using a project snapshot as a basis. You can create new workspaces within a Builders project. You can create workspaces from the Perforce UI.
+A workspace in NetApp workload factory for Builders is a Perforce representation of a project at a specific moment in time. Workspaces are created using a project snapshot as a basis. You can create new workspaces within a Builders project. You can create workspaces from the Perforce UI.
 
 //== Create a workspace
 //You can create a new workspace from a snapshot of a project.

--- a/get-help-builders.adoc
+++ b/get-help-builders.adoc
@@ -2,7 +2,7 @@
 sidebar: sidebar
 permalink: get-help-builders.html
 keywords: help, ticket, open support case, support, netapp support, technical support, call support, phone number, open ticket, web ticket, open an issue
-summary: NetApp provides support for workload factory and its cloud services in a variety of ways. Extensive free self-support options are available 24x7, such as knowledgebase (KB) articles and a community forum. Your support registration includes remote technical support via web ticketing.
+summary: NetApp provides support for Workload Factory and its cloud services in a variety of ways. Extensive free self-support options are available 24x7, such as knowledgebase (KB) articles and a community forum. Your support registration includes remote technical support via web ticketing.
 ---
 = Get help with Builders
 :icons: font

--- a/integrate-perforce.adoc
+++ b/integrate-perforce.adoc
@@ -19,11 +19,11 @@ Integrate Builders with the Perforce Helix Visual Client (P4V) so that developer
 . Go to *View* > *Workload Factory*.
 
 .Result
-The NetApp workload factory for Builders web UI appears as an HTML tab within the P4V client.
+The NetApp Workload Factory for Builders web UI appears as an HTML tab within the P4V client.
 
-//. Log in to workload factory using one of the link:https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
+//. Log in to Workload Factory using one of the link:https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
 //. Optionally, select *Go to P4v integration demo* to be guided through the integration process with an instructional video.
-//. Follow the instructions to integrate workload factory for Builders with the Perforce Helix Visual Client.
+//. Follow the instructions to integrate Workload Factory for Builders with the Perforce Helix Visual Client.
 //. When you are done, select *OK*.
 
 .What's next?

--- a/integrate-perforce.adoc
+++ b/integrate-perforce.adoc
@@ -19,7 +19,7 @@ Integrate Builders with the Perforce Helix Visual Client (P4V) so that developer
 . Go to *View* > *Workload Factory*.
 
 .Result
-The BlueXP workload factory for Builders web UI appears as an HTML tab within the P4V client.
+The NetApp workload factory for Builders web UI appears as an HTML tab within the P4V client.
 
 //. Log in to workload factory using one of the link:https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
 //. Optionally, select *Go to P4v integration demo* to be guided through the integration process with an instructional video.

--- a/known-limitations.adoc
+++ b/known-limitations.adoc
@@ -5,7 +5,7 @@ keywords: limitations, builders
 summary: Known limitations identify platforms, devices, or functions that are not supported by this release of the product, or that do not interoperate correctly with it. Review these limitations carefully.
 ---
 
-= Known limitations of NetApp workload factory for Builders
+= Known limitations of NetApp Workload Factory for Builders
 :icons: font
 :imagesdir: ./media/
 
@@ -13,5 +13,5 @@ summary: Known limitations identify platforms, devices, or functions that are no
 Known limitations identify platforms, devices, or functions that are not supported by this release of the product, or that do not interoperate correctly with it. Review these limitations carefully.
 
 == Operator permissions required
-NetApp workload factory for Builders requires Operator permissions to function correctly.
+NetApp Workload Factory for Builders requires Operator permissions to function correctly.
 

--- a/known-limitations.adoc
+++ b/known-limitations.adoc
@@ -5,7 +5,7 @@ keywords: limitations, builders
 summary: Known limitations identify platforms, devices, or functions that are not supported by this release of the product, or that do not interoperate correctly with it. Review these limitations carefully.
 ---
 
-= Known limitations of BlueXP workload factory for Builders
+= Known limitations of NetApp workload factory for Builders
 :icons: font
 :imagesdir: ./media/
 
@@ -13,5 +13,5 @@ summary: Known limitations identify platforms, devices, or functions that are no
 Known limitations identify platforms, devices, or functions that are not supported by this release of the product, or that do not interoperate correctly with it. Review these limitations carefully.
 
 == Operator permissions required
-BlueXP workload factory for Builders requires Operator permissions to function correctly.
+NetApp workload factory for Builders requires Operator permissions to function correctly.
 

--- a/learn-builders.adoc
+++ b/learn-builders.adoc
@@ -56,7 +56,7 @@ No special licenses are needed from NetApp to use the Builders capabilities of w
 //=== Integrated AWS services
 //Builders includes the following integrated AWS services: 
 
-=== Regions
+== Regions
 Builders is supported in all commercial regions where FSx for ONTAP is supported. https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/[View supported Amazon regions.^]
 
 The following AWS regions aren't supported: 

--- a/learn-builders.adoc
+++ b/learn-builders.adoc
@@ -56,7 +56,7 @@ No special licenses are needed from NetApp to use the Builders capabilities of w
 //=== Integrated AWS services
 //Builders includes the following integrated AWS services: 
 
-=== Supported regions
+=== Regions
 Builders is supported in all commercial regions where FSx for ONTAP is supported. https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/[View supported Amazon regions.^]
 
 The following AWS regions aren't supported: 

--- a/learn-builders.adoc
+++ b/learn-builders.adoc
@@ -2,26 +2,26 @@
 sidebar: sidebar
 permalink: learn-builders.html
 keywords: software builders, development, benefits
-summary: NetApp workload factory for Builders is a rapid build environment creation tool for software builders. 
+summary: NetApp Workload Factory for Builders is a rapid build environment creation tool for software builders. 
 ---
-= Learn about NetApp workload factory for Builders
+= Learn about NetApp Workload Factory for Builders
 :icons: font
 :imagesdir: ./media/
 
 [.lead]
-NetApp workload factory for Builders is a rapid build environment creation tool for software builders. It enables fast setup of personal development environments, saving time and enabling self-service for developers while empowering DevOps teams to retain control of the infrastructure. Using Builders, software developers can quickly create workspaces without needing specialized data storage or understanding of the development infrastructure.
+NetApp Workload Factory for Builders is a rapid build environment creation tool for software builders. It enables fast setup of personal development environments, saving time and enabling self-service for developers while empowering DevOps teams to retain control of the infrastructure. Using Builders, software developers can quickly create workspaces without needing specialized data storage or understanding of the development infrastructure.
 
-== What is NetApp workload factory for Builders?
-NetApp workload factory for Builders is designed to streamline the way developers manage and interact with different versions of their software. Builders integrates seamlessly with Perforce Helix Core to provide instant clones of software versions, creating ready-to-use workspaces for development, QA, and CI/CD processes. 
+== What is NetApp Workload Factory for Builders?
+NetApp Workload Factory for Builders is designed to streamline the way developers manage and interact with different versions of their software. Builders integrates seamlessly with Perforce Helix Core to provide instant clones of software versions, creating ready-to-use workspaces for development, QA, and CI/CD processes. 
 
 With Builders, you can easily create a project and assign a volume that represents your software environment and its artifacts. As you update your software, you can take snapshots of the volume, capturing the state of your software at that moment. This means you can access any version of your software instantly without the need to resync with the version control system, saving valuable time and resources.
 
 By leveraging ONTAP's snapshot and clone capabilities, Builders enhances your development workflow, allowing for rapid access to multiple versions of your software, accelerating development cycles, and helping to reduce time to market.
 
-For more information about workload factory, refer to the link:https://docs.netapp.com/us-en/workload-setup-admin/workload-factory-overview.html[workload factory overview^].
+For more information about Workload Factory, refer to the link:https://docs.netapp.com/us-en/workload-setup-admin/workload-factory-overview.html[Workload Factory overview^].
 
-== NetApp workload factory for Builders features
-NetApp workload factory for Builders offers the following features:
+== NetApp Workload Factory for Builders features
+NetApp Workload Factory for Builders offers the following features:
 
 * Create, edit, and remove projects
 * Create snapshots of defined software versions
@@ -35,23 +35,23 @@ NetApp workload factory for Builders offers the following features:
 When you use Builders, you create a project and assign a volume that represents your software environment and its artifacts. Each time that you create a new version of the software, you need resync the volume data and create a project snapshot to mark the volume state as a known version. The project source volume might get rolling updates and have multiple snapshots to mark multiple versions. You can use each snapshot immediately as an instant clone, a dedicated or shared editable repository available to developers, QA or build processes. A clone in the context of a specific software version is a workspace.
  
 
-== Operational modes in workload factory
-Three different operational modes - _basic_, _read-only_ and _read/write_ - offer flexible options for deployment inside and outside of workload factory. Gain immediate value at zero-trust in _basic_ mode with code snippets for use outside workload factory. Get incremental value with incremental trust in _read-only_ and _read/write_ modes. 
+== Operational modes in Workload Factory
+Three different operational modes - _basic_, _read-only_ and _read/write_ - offer flexible options for deployment inside and outside of Workload Factory. Gain immediate value at zero-trust in _basic_ mode with code snippets for use outside Workload Factory. Get incremental value with incremental trust in _read-only_ and _read/write_ modes. 
 
-Learn more about link:https://docs.netapp.com/us-en/workload-setup-admin/operational-modes.html[operational modes in workload factory^].
+Learn more about link:https://docs.netapp.com/us-en/workload-setup-admin/operational-modes.html[operational modes in Workload Factory^].
 
-== Automation with workload factory Codebox
+== Automation with Workload Factory Codebox
 Workload factory introduces built-in automation with the _Codebox_. The Codebox offers the following automation benefits: 
 
 * *Code snippet generation*: Infrastructure-as-Code (IaC) snippets are generated during resource creation, enabling seamless integration with existing orchestration workflows. 
-* *Infrastructure-as-code co-pilot*: the Codebox is an Infrastructure-as-code (IaC) co-pilot that helps developers and DevOps generate code to execute any operation supported by workload factory.  
+* *Infrastructure-as-code co-pilot*: the Codebox is an Infrastructure-as-code (IaC) co-pilot that helps developers and DevOps generate code to execute any operation supported by Workload Factory.  
 * *Code viewer and automation catalog*: the Codebox provides a code viewer for quick analysis of automation and an automation catalog for quick future re-use. 
 
 == Cost
-There is no cost for using the Builders capability of workload factory.
+There is no cost for using the Builders capability of Workload Factory.
 
 == Licensing
-No special licenses are needed from NetApp to use the Builders capabilities of workload factory.
+No special licenses are needed from NetApp to use the Builders capabilities of Workload Factory.
 
 //=== Integrated AWS services
 //Builders includes the following integrated AWS services: 
@@ -69,4 +69,4 @@ The following AWS regions aren't supported:
 == Getting help
 Amazon FSx for NetApp ONTAP is an AWS first-party solution. For questions or technical support issues associated with your FSx for ONTAP file system, infrastructure, or any solution using this service, use the Support Center in your AWS Management Console to open a support case with AWS. Select the “FSx for ONTAP” service and appropriate category. Provide the remaining information required to create your AWS support case.
 
-For general questions about workload factory or workload factory applications and services, refer to link:get-help-builders.html[Get help for Builders for workload factory].
+For general questions about Workload Factory or Workload Factory applications and services, refer to link:get-help-builders.html[Get help for Builders for Workload Factory].

--- a/learn-builders.adoc
+++ b/learn-builders.adoc
@@ -2,17 +2,17 @@
 sidebar: sidebar
 permalink: learn-builders.html
 keywords: software builders, development, benefits
-summary: BlueXP workload factory for Builders is a rapid build environment creation tool for software builders. 
+summary: NetApp workload factory for Builders is a rapid build environment creation tool for software builders. 
 ---
-= Learn about BlueXP workload factory for Builders
+= Learn about NetApp workload factory for Builders
 :icons: font
 :imagesdir: ./media/
 
 [.lead]
-BlueXP workload factory for Builders is a rapid build environment creation tool for software builders. It enables fast setup of personal development environments, saving time and enabling self-service for developers while empowering DevOps teams to retain control of the infrastructure. Using Builders, software developers can quickly create workspaces without needing specialized data storage or understanding of the development infrastructure.
+NetApp workload factory for Builders is a rapid build environment creation tool for software builders. It enables fast setup of personal development environments, saving time and enabling self-service for developers while empowering DevOps teams to retain control of the infrastructure. Using Builders, software developers can quickly create workspaces without needing specialized data storage or understanding of the development infrastructure.
 
-== What is BlueXP workload factory for Builders?
-BlueXP workload factory for Builders is designed to streamline the way developers manage and interact with different versions of their software. Builders integrates seamlessly with Perforce Helix Core to provide instant clones of software versions, creating ready-to-use workspaces for development, QA, and CI/CD processes. 
+== What is NetApp workload factory for Builders?
+NetApp workload factory for Builders is designed to streamline the way developers manage and interact with different versions of their software. Builders integrates seamlessly with Perforce Helix Core to provide instant clones of software versions, creating ready-to-use workspaces for development, QA, and CI/CD processes. 
 
 With Builders, you can easily create a project and assign a volume that represents your software environment and its artifacts. As you update your software, you can take snapshots of the volume, capturing the state of your software at that moment. This means you can access any version of your software instantly without the need to resync with the version control system, saving valuable time and resources.
 
@@ -20,8 +20,8 @@ By leveraging ONTAP's snapshot and clone capabilities, Builders enhances your de
 
 For more information about workload factory, refer to the link:https://docs.netapp.com/us-en/workload-setup-admin/workload-factory-overview.html[workload factory overview^].
 
-== BlueXP workload factory for Builders features
-BlueXP workload factory for Builders offers the following features:
+== NetApp workload factory for Builders features
+NetApp workload factory for Builders offers the following features:
 
 * Create, edit, and remove projects
 * Create snapshots of defined software versions

--- a/legal-notices.adoc
+++ b/legal-notices.adoc
@@ -4,7 +4,7 @@ sidebar: sidebar
 keywords: # no keywords
 summary: # no summary
 ---
-= Legal notices for NetApp workload factory for Builders
+= Legal notices for NetApp Workload Factory for Builders
 :icons: font
 :imagesdir: ./media/
 

--- a/legal-notices.adoc
+++ b/legal-notices.adoc
@@ -4,7 +4,7 @@ sidebar: sidebar
 keywords: # no keywords
 summary: # no summary
 ---
-= Legal notices for BlueXP workload factory for Builders
+= Legal notices for NetApp workload factory for Builders
 :icons: font
 :imagesdir: ./media/
 

--- a/manage-projects.adoc
+++ b/manage-projects.adoc
@@ -2,21 +2,21 @@
 sidebar: sidebar
 permalink: manage-projects.html
 keywords: Microsoft SQL Server instance, server instance, manage host, view host, database host, database instance, manage, unmanage
-summary: Manage Microsoft SQL Server instances in workload factory for Databases. 
+summary: Manage Microsoft SQL Server instances in Workload Factory for Databases. 
 ---
 = Manage Builders projects
 :icons: font
 :imagesdir: ./media/
 
 [.lead]
-You can manage Builders projects to control how your code and artifacts are managed for each project in NetApp workload factory for Builders. 
+You can manage Builders projects to control how your code and artifacts are managed for each project in NetApp Workload Factory for Builders. 
 
 == Create a project
 
 You can create a new Builders project so that you can leverage the data protection features of your Amazon FSX for NetApp ONTAP filesystem for your code and artifacts. 
 
 .Steps
-. Log in to workload factory using one of the link:https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
+. Log in to Workload Factory using one of the link:https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
 . In the Builders tile, select *Create project*. 
 . On the Create project page, provide the following:
 .. *Project name*: Enter a name for the project.
@@ -31,7 +31,7 @@ You can only select filesystems that are configured with a link. https://docs.ne
 +
 You can only select volumes that are configured as an NFS share.
 .. *Operation policies*: Provide limits for project clones:
-... *Maximum retention in days*: Enter the maximum number of days that a clone should be retained. After this number of days, workload factory removes the clone.
+... *Maximum retention in days*: Enter the maximum number of days that a clone should be retained. After this number of days, Workload Factory removes the clone.
 ... *Maximum number of clones per user or group*: Enter the maximum number of clones that can be provisioned for a user or group.
 ... *Maximum clone size in GiB*: Enter the maximum size in GiB of a project clone.
 .. *Access policies*: Explicitly grant project access to specific users or groups:
@@ -47,10 +47,10 @@ For example: `User1234`
 The project is created, and appears in the list of projects on the Projects page.
 
 == View existing projects
-You can view existing projects created in NetApp workload factory for Builders by following these steps. 
+You can view existing projects created in NetApp Workload Factory for Builders by following these steps. 
 
 .Steps
-. Log in to workload factory using one of the link:https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
+. Log in to Workload Factory using one of the link:https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
 . In the Builders tile, select *Go to Projects page*. 
 . View the existing projects listed on the Projects page.
 
@@ -58,7 +58,7 @@ You can view existing projects created in NetApp workload factory for Builders b
 You can edit the settings of a project at any time. 
 
 .Steps
-. Log in to workload factory using one of the link:https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
+. Log in to Workload Factory using one of the link:https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
 . In the Builders tile, select *Go to Projects page*. 
 . On the Projects page, select image:icon-action.png[the option button] for the project you want to edit.
 . Make any needed changes to the project configuration.
@@ -68,7 +68,7 @@ You can edit the settings of a project at any time.
 A clone or snapshot of a project is known as a workspace. When you create a workspace, it is retained for as long as the project's operation policy allows. You can view existing workspaces for a project by following these steps.
 
 .Steps
-. Log in to workload factory using one of the link:https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
+. Log in to Workload Factory using one of the link:https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
 . In the Builders tile, select *Go to Projects page*. 
 . On the Projects page, choose a project and select *View*.
 . View the status and details of all workspaces for this project.
@@ -78,7 +78,7 @@ A clone or snapshot of a project is known as a workspace. When you create a work
 You can delete a project when it is no longer needed by following these steps.
 
 .Steps
-. Log in to workload factory using one of the link:https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
+. Log in to Workload Factory using one of the link:https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
 . In the Builders tile, select *Go to Projects page*. 
 . On the Projects page, select image:icon-action.png[the option button] for the project you want to delete.
 . Select *Delete*.

--- a/manage-projects.adoc
+++ b/manage-projects.adoc
@@ -9,7 +9,7 @@ summary: Manage Microsoft SQL Server instances in workload factory for Databases
 :imagesdir: ./media/
 
 [.lead]
-You can manage Builders projects to control how your code and artifacts are managed for each project in BlueXP workload factory for Builders. 
+You can manage Builders projects to control how your code and artifacts are managed for each project in NetApp workload factory for Builders. 
 
 == Create a project
 
@@ -47,7 +47,7 @@ For example: `User1234`
 The project is created, and appears in the list of projects on the Projects page.
 
 == View existing projects
-You can view existing projects created in BlueXP workload factory for Builders by following these steps. 
+You can view existing projects created in NetApp workload factory for Builders by following these steps. 
 
 .Steps
 . Log in to workload factory using one of the link:https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].

--- a/project.yml
+++ b/project.yml
@@ -22,7 +22,7 @@ sidebar:
         url: /known-limitations.html 
   - title: Get started
     entries: 
-      - title: Learn about NetApp workload factory for Builders
+      - title: Learn about NetApp Workload Factory for Builders
         url: /learn-builders.html 
       - title: Quick start
         url: /quick-start-builders.html
@@ -68,5 +68,5 @@ sidebar:
     url: /legal-notices.html
 
 product-family:
-  name: NetApp workload factory
+  name: NetApp Workload Factory
   repo: workload-family

--- a/project.yml
+++ b/project.yml
@@ -22,7 +22,7 @@ sidebar:
         url: /known-limitations.html 
   - title: Get started
     entries: 
-      - title: Learn about BlueXP workload factory for Builders
+      - title: Learn about NetApp workload factory for Builders
         url: /learn-builders.html 
       - title: Quick start
         url: /quick-start-builders.html
@@ -68,5 +68,5 @@ sidebar:
     url: /legal-notices.html
 
 product-family:
-  name: BlueXP workload factory
+  name: NetApp workload factory
   repo: workload-family

--- a/quick-start-builders.adoc
+++ b/quick-start-builders.adoc
@@ -12,15 +12,15 @@ summary: Databases has three different modes that have different requirements.
 [.lead]
 Get started creating a Builders project. Administrators and team leads can use Builders to administer projects and workspaces for teams of developers.
 
-.image:https://raw.githubusercontent.com/NetAppDocs/common/main/media/number-1.png[One] Log in to workload factory
+.image:https://raw.githubusercontent.com/NetAppDocs/common/main/media/number-1.png[One] Log in to Workload Factory
 
 [role="quick-margin-para"]
-You'll need to https://docs.netapp.com/us-en/workload-setup-admin/sign-up-saas.html[set up an account with workload factory^] and log in using one of the https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
+You'll need to https://docs.netapp.com/us-en/workload-setup-admin/sign-up-saas.html[set up an account with Workload Factory^] and log in using one of the https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
 
 .image:https://raw.githubusercontent.com/NetAppDocs/common/main/media/number-2.png[Two] Add AWS credentials and permissions to your account
 
 [role="quick-margin-para"]
-You can use workload factory in _Basic_ mode without adding credentials to access your AWS account. Adding AWS credentials to workload factory in either _read-only_ or _read/write_ mode gives your workload factory account the permissions needed to create and manage FSx for ONTAP file systems, and to deploy and manage Builders projects.
+You can use Workload Factory in _Basic_ mode without adding credentials to access your AWS account. Adding AWS credentials to Workload Factory in either _read-only_ or _read/write_ mode gives your Workload Factory account the permissions needed to create and manage FSx for ONTAP file systems, and to deploy and manage Builders projects.
 
 [role="quick-margin-para"]
 https://docs.netapp.com/us-en/workload-setup-admin/add-credentials.html[Learn how to add credentials and permissions^].

--- a/requirements-builders.adoc
+++ b/requirements-builders.adoc
@@ -2,7 +2,7 @@
 sidebar: sidebar
 permalink: requirements-builders.html
 keywords: Builders, FSx, project, projects
-summary: Ensure that workload factory and AWS are set up properly before you begin using BlueXP workload factory for Builders. This includes having your AWS log in credentials, a deployed FSx for ONTAP file system, and more.
+summary: Ensure that workload factory and AWS are set up properly before you begin using NetApp workload factory for Builders. This includes having your AWS log in credentials, a deployed FSx for ONTAP file system, and more.
 ---
 
 = Builders requirements
@@ -10,7 +10,7 @@ summary: Ensure that workload factory and AWS are set up properly before you beg
 :imagesdir: ./media/
 
 [.lead]
-Ensure that workload factory and AWS are set up properly before you begin using BlueXP workload factory for Builders. This includes having your AWS log in credentials, a deployed FSx for ONTAP file system, and more.
+Ensure that workload factory and AWS are set up properly before you begin using NetApp workload factory for Builders. This includes having your AWS log in credentials, a deployed FSx for ONTAP file system, and more.
 
 Workload factory login and account::
 You'll need to https://docs.netapp.com/us-en/workload-setup-admin/sign-up-saas.html[set up an account with workload factory^] and log in using one of the https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].

--- a/requirements-builders.adoc
+++ b/requirements-builders.adoc
@@ -2,7 +2,7 @@
 sidebar: sidebar
 permalink: requirements-builders.html
 keywords: Builders, FSx, project, projects
-summary: Ensure that workload factory and AWS are set up properly before you begin using NetApp workload factory for Builders. This includes having your AWS log in credentials, a deployed FSx for ONTAP file system, and more.
+summary: Ensure that Workload Factory and AWS are set up properly before you begin using NetApp Workload Factory for Builders. This includes having your AWS log in credentials, a deployed FSx for ONTAP file system, and more.
 ---
 
 = Builders requirements
@@ -10,13 +10,13 @@ summary: Ensure that workload factory and AWS are set up properly before you beg
 :imagesdir: ./media/
 
 [.lead]
-Ensure that workload factory and AWS are set up properly before you begin using NetApp workload factory for Builders. This includes having your AWS log in credentials, a deployed FSx for ONTAP file system, and more.
+Ensure that Workload Factory and AWS are set up properly before you begin using NetApp Workload Factory for Builders. This includes having your AWS log in credentials, a deployed FSx for ONTAP file system, and more.
 
 Workload factory login and account::
-You'll need to https://docs.netapp.com/us-en/workload-setup-admin/sign-up-saas.html[set up an account with workload factory^] and log in using one of the https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
+You'll need to https://docs.netapp.com/us-en/workload-setup-admin/sign-up-saas.html[set up an account with Workload Factory^] and log in using one of the https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
 
 AWS credentials and permissions::
-You need to add AWS credentials to workload factory with read/write permissions, which means you'll be using workload factory in _read/write_ mode for Builders.
+You need to add AWS credentials to Workload Factory with read/write permissions, which means you'll be using Workload Factory in _read/write_ mode for Builders.
 
 _Basic_ mode and _read-only_ mode permissions are not supported at this time.
 //+
@@ -24,7 +24,7 @@ _Basic_ mode and _read-only_ mode permissions are not supported at this time.
 //+
 //image:screenshot-ai-permissions.png[A screenshot showing the permissions setting for full management of AI resources.]
 //+
-https://docs.netapp.com/us-en/workload-setup-admin/add-credentials.html[Learn how to add AWS credentials to workload factory^]
+https://docs.netapp.com/us-en/workload-setup-admin/add-credentials.html[Learn how to add AWS credentials to Workload Factory^]
 
 FSx for ONTAP file system::
 You need a minimum of one FSx for ONTAP file system:

--- a/support-registration.adoc
+++ b/support-registration.adoc
@@ -2,14 +2,14 @@
 sidebar: sidebar
 permalink: support-registration.html
 keywords: support registration, register for support, support, nss account, add nss account
-summary: Before you can open a support case with NetApp technical support, you need to add a NetApp Support Site account to workload factory and then register for support.
+summary: Before you can open a support case with NetApp technical support, you need to add a NetApp Support Site account to Workload Factory and then register for support.
 ---
 
-= Register for support for NetApp workload factory for Builders
+= Register for support for NetApp Workload Factory for Builders
 :icons: font
 :imagesdir: ./media/
 
 [.lead]
-Before you can open a support case with NetApp technical support, you need to add a NetApp Support Site account to workload factory and then register for support.
+Before you can open a support case with NetApp technical support, you need to add a NetApp Support Site account to Workload Factory and then register for support.
 
 include::https://raw.githubusercontent.com/NetAppDocs/workload-family/main/_include/support-registration.adoc[]

--- a/support-registration.adoc
+++ b/support-registration.adoc
@@ -5,7 +5,7 @@ keywords: support registration, register for support, support, nss account, add 
 summary: Before you can open a support case with NetApp technical support, you need to add a NetApp Support Site account to workload factory and then register for support.
 ---
 
-= Register for support for BlueXP workload factory for Builders
+= Register for support for NetApp workload factory for Builders
 :icons: font
 :imagesdir: ./media/
 

--- a/version-projects.adoc
+++ b/version-projects.adoc
@@ -4,7 +4,7 @@ permalink: version-projects.html
 keywords: snapshot, clone, project, protect, API, version, versions, versioning
 summary: Manage versions of your Builders projects using snapshots and clones. 
 ---
-= Manage versions of BlueXP workload factory for Builders projects
+= Manage versions of NetApp workload factory for Builders projects
 :icons: font
 :imagesdir: ./media/
 

--- a/version-projects.adoc
+++ b/version-projects.adoc
@@ -4,18 +4,18 @@ permalink: version-projects.html
 keywords: snapshot, clone, project, protect, API, version, versions, versioning
 summary: Manage versions of your Builders projects using snapshots and clones. 
 ---
-= Manage versions of NetApp workload factory for Builders projects
+= Manage versions of NetApp Workload Factory for Builders projects
 :icons: font
 :imagesdir: ./media/
 
 [.lead]
-Work with different versions of your Builders projects by creating on-demand snapshots and clones directly from workload factory. Snapshots and clones of a project are stored in the filesystem that was associated with the project when it was created. You can also manage snapshots and clones using the https://console.workloads.netapp.com/api-doc[workload factory REST API^].
+Work with different versions of your Builders projects by creating on-demand snapshots and clones directly from Workload Factory. Snapshots and clones of a project are stored in the filesystem that was associated with the project when it was created. You can also manage snapshots and clones using the https://console.workloads.netapp.com/api-doc[Workload Factory REST API^].
 
 == Create a snapshot of a project
 You can create a snapshot of a project by following these steps.
 
 .Steps
-. Log in to workload factory using one of the link:https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
+. Log in to Workload Factory using one of the link:https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
 . In the Builders tile, select *Go to Projects page*. 
 . On the Projects page, select image:icon-action.png[the option button] for the project you want to snapshot.
 . In the resulting menu, select *Create a snapshot*.
@@ -25,7 +25,7 @@ You can create a snapshot of a project by following these steps.
 Clone a Builders project from a snapshot by following these steps. When you create a clone, a new editable volume is created to contain the clone.
 
 .Steps
-. Log in to workload factory using one of the link:https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
+. Log in to Workload Factory using one of the link:https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
 . In the Builders tile, select *Go to Projects page*. 
 . On the Projects page, select image:icon-action.png[the option button] for the project you want to clone.
 . In the resulting menu, select *Create a clone*.

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -12,7 +12,7 @@ summary: Learn what's new with Workload Factory for Databases.
 Learn what's new with the Builders capability of Workload Factory.
 
 //tag::whats-new[]
-== 16 June 2025
+== 5 October 2025
 
 include::_whatsnew/2025-10-05.adoc[]
 

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -4,7 +4,7 @@ permalink: whats-new.html
 keywords: what's new, features, new, release notes, enhancements, fixes, new features, workload factory, builders, workload factory
 summary: Learn what's new with workload factory for Databases.
 ---
-= What's new with BlueXP workload factory for Builders
+= What's new with NetApp workload factory for Builders
 :icons: font
 :imagesdir: ./media/
 

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -1,15 +1,15 @@
 ---
 sidebar: sidebar
 permalink: whats-new.html
-keywords: what's new, features, new, release notes, enhancements, fixes, new features, workload factory, builders, workload factory
-summary: Learn what's new with workload factory for Databases.
+keywords: what's new, features, new, release notes, enhancements, fixes, new features, Workload Factory, builders, Workload Factory
+summary: Learn what's new with Workload Factory for Databases.
 ---
-= What's new with NetApp workload factory for Builders
+= What's new with NetApp Workload Factory for Builders
 :icons: font
 :imagesdir: ./media/
 
 [.lead]
-Learn what's new with the Builders capability of workload factory.
+Learn what's new with the Builders capability of Workload Factory.
 
 //tag::whats-new[]
 == 16 June 2025

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -14,13 +14,16 @@ Learn what's new with the Builders capability of Workload Factory.
 //tag::whats-new[]
 == 16 June 2025
 
+include::_whatsnew/2025-10-05.adoc[]
+
+== 16 June 2025
+
 include::_whatsnew/2025-06-16.adoc[]
 
 == 4 May 2025
 
 include::_whatsnew/2025-05-04.adoc[]
-
+//end::whats-new[]
 == 1 December 2024
 
 include::_whatsnew/2024-12-01.adoc[]
-//end::whats-new[]


### PR DESCRIPTION
This pull request updates the documentation to reflect the renaming of "BlueXP Workload Factory for Builders" to "NetApp Workload Factory for Builders" throughout the docs. It also updates branding, terminology, and relevant links to ensure consistency with the new product name and its expanded role. No functional or technical changes are included—this is a comprehensive documentation and branding update.

**Branding and terminology updates:**

* Replaced all instances of "BlueXP Workload Factory for Builders" with "NetApp Workload Factory for Builders" across documentation files, including titles, summaries, leads, and section headings. [[1]](diffhunk://#diff-eeb91e423bf43be21fa638d740fc3019a84e78a15a5f858410a25042d111d6b6L2-R3) [[2]](diffhunk://#diff-9c83fc935210f6b75b248a136408ea66211a01cb307e7282894ce992a9d190d2L2-R2) [[3]](diffhunk://#diff-3e141e229eff55880434b9817a5fa1614a772722f4e8b281c4915e27af9eefa0L2-R4) [[4]](diffhunk://#diff-ef37e889dfad2780e964939ad254e0eb7bb609f4abca4d68e501982bb2a6e46bL5-R12) [[5]](diffhunk://#diff-d2265dbd37f8221c99dd481e63a129b7ddcc6c89f26c4fb6ef9e44d7bf54a6e2L5-R5) [[6]](diffhunk://#diff-92c2daf9bd62c77dcba3dedb25e2c1c57c500218cf613c613089823da1d9f8d1L22-R26) [[7]](diffhunk://#diff-b316e005b612d44fbc476999cb1e27d5e85862ca5aa5704a32d1c55ed09647caL8-R16) [[8]](diffhunk://#diff-18d08075278fb6aa0ddbcb1950d62cba5e3f6d4e3b1bb6665ee2ddd69d42f670L5-R24) [[9]](diffhunk://#diff-c5470b125b974b7865847e620b7e8054bd7c50437b4b441aa302c5eceb095f76L7-R7) [[10]](diffhunk://#diff-dd00b8bda5dbb42860e20358fcf7189b4d13ed2cc8dad98a0a6af62946429f6cL5-R19)
* Updated terminology in operational descriptions, replacing "workload factory" and "BlueXP" with "Workload Factory" and "NetApp" as appropriate. [[1]](diffhunk://#diff-eeb91e423bf43be21fa638d740fc3019a84e78a15a5f858410a25042d111d6b6L2-R3) [[2]](diffhunk://#diff-18d08075278fb6aa0ddbcb1950d62cba5e3f6d4e3b1bb6665ee2ddd69d42f670L5-R24) [[3]](diffhunk://#diff-18d08075278fb6aa0ddbcb1950d62cba5e3f6d4e3b1bb6665ee2ddd69d42f670L38-R59) [[4]](diffhunk://#diff-ef37e889dfad2780e964939ad254e0eb7bb609f4abca4d68e501982bb2a6e46bL24-R26) [[5]](diffhunk://#diff-dd00b8bda5dbb42860e20358fcf7189b4d13ed2cc8dad98a0a6af62946429f6cL34-R34)

**Documentation content updates:**

* Added a new section announcing the rebranding from BlueXP to NetApp Workload Factory and explaining the rationale.
* Updated links, feature lists, and operational mode descriptions to use the new product name and point to the correct resources. [[1]](diffhunk://#diff-eeb91e423bf43be21fa638d740fc3019a84e78a15a5f858410a25042d111d6b6R29-R34) [[2]](diffhunk://#diff-9c83fc935210f6b75b248a136408ea66211a01cb307e7282894ce992a9d190d2L2-R2) [[3]](diffhunk://#diff-18d08075278fb6aa0ddbcb1950d62cba5e3f6d4e3b1bb6665ee2ddd69d42f670L72-R72) [[4]](diffhunk://#diff-18d08075278fb6aa0ddbcb1950d62cba5e3f6d4e3b1bb6665ee2ddd69d42f670L38-R59)

**Consistency improvements:**

* Ensured all usage of the product name, feature descriptions, and process steps are consistent with the new branding and terminology across all documentation files. [[1]](diffhunk://#diff-f3f3d4da075539fb41f9d692eb3bf12660444dde99647ab783584dd11d0ef0ccL2-R2) [[2]](diffhunk://#diff-a11b1bb29c0ab3632ed17902114ca6db7f98ac130ebbd85580b0a197a20c1949L12-R12) [[3]](diffhunk://#diff-18d08075278fb6aa0ddbcb1950d62cba5e3f6d4e3b1bb6665ee2ddd69d42f670L38-R59) [[4]](diffhunk://#diff-dd00b8bda5dbb42860e20358fcf7189b4d13ed2cc8dad98a0a6af62946429f6cL34-R34)