### PR TITLE
Nov 2 release permissions updates.

### DIFF
--- a/learn-builders.adoc
+++ b/learn-builders.adoc
@@ -16,7 +16,7 @@ NetApp Workload Factory for Builders is designed to streamline the way developer
 
 With Builders, you can easily create a project and assign a volume that represents your software environment and its artifacts. As you update your software, you can take snapshots of the volume, capturing the state of your software at that moment. This means you can access any version of your software instantly without the need to resync with the version control system, saving valuable time and resources.
 
-By leveraging ONTAP's snapshot and clone capabilities, Builders enhances your development workflow, allowing for rapid access to multiple versions of your software, accelerating development cycles, and helping to reduce time to market.
+Using the snapshot and clone capabilities of NetApp ONTAP, Builders enhances your development workflow by enabling rapid access to multiple versions of your software, accelerating development cycles, and helping to reduce time to market.
 
 For more information about Workload Factory, refer to the link:https://docs.netapp.com/us-en/workload-setup-admin/workload-factory-overview.html[Workload Factory overview^].
 
@@ -34,7 +34,6 @@ NetApp Workload Factory for Builders offers the following features:
 == Projects and workspaces in Builders
 When you use Builders, you create a project and assign a volume that represents your software environment and its artifacts. Each time that you create a new version of the software, you need resync the volume data and create a project snapshot to mark the volume state as a known version. The project source volume might get rolling updates and have multiple snapshots to mark multiple versions. You can use each snapshot immediately as an instant clone, a dedicated or shared editable repository available to developers, QA or build processes. A clone in the context of a specific software version is a workspace.
  
-
 == Permission policies in Workload Factory
 Workload Factory offers flexible permission options. Gain immediate value at zero-trust without granting permissions using code snippets from the Codebox for use outside Workload Factory. Get incremental value with permission policies that build on top of one another starting with resource detection and analysis, then operations and remediation, and then deployment inside Workload Factory.  
 

--- a/learn-builders.adoc
+++ b/learn-builders.adoc
@@ -35,10 +35,10 @@ NetApp Workload Factory for Builders offers the following features:
 When you use Builders, you create a project and assign a volume that represents your software environment and its artifacts. Each time that you create a new version of the software, you need resync the volume data and create a project snapshot to mark the volume state as a known version. The project source volume might get rolling updates and have multiple snapshots to mark multiple versions. You can use each snapshot immediately as an instant clone, a dedicated or shared editable repository available to developers, QA or build processes. A clone in the context of a specific software version is a workspace.
  
 
-== Operational modes in Workload Factory
-Three different operational modes - _basic_, _read-only_ and _read/write_ - offer flexible options for deployment inside and outside of Workload Factory. Gain immediate value at zero-trust in _basic_ mode with code snippets for use outside Workload Factory. Get incremental value with incremental trust in _read-only_ and _read/write_ modes. 
+== Permission policies in Workload Factory
+Workload Factory offers flexible permission options. Gain immediate value at zero-trust without granting permissions using code snippets from the Codebox for use outside Workload Factory. Get incremental value with permission policies that build on top of one another starting with resource detection and analysis, then operations and remediation, and then deployment inside Workload Factory.  
 
-Learn more about link:https://docs.netapp.com/us-en/workload-setup-admin/operational-modes.html[operational modes in Workload Factory^].
+Learn more about link:https://docs.netapp.com/us-en/workload-setup-admin/permissions-reference.html[permissions in Workload Factory^].
 
 == Automation with Workload Factory Codebox
 Workload factory introduces built-in automation with the _Codebox_. The Codebox offers the following automation benefits: 

--- a/learn-builders.adoc
+++ b/learn-builders.adoc
@@ -12,11 +12,11 @@ summary: NetApp Workload Factory for Builders is a rapid build environment creat
 NetApp Workload Factory for Builders is a rapid build environment creation tool for software builders. It enables fast setup of personal development environments, saving time and enabling self-service for developers while empowering DevOps teams to retain control of the infrastructure. Using Builders, software developers can quickly create workspaces without needing specialized data storage or understanding of the development infrastructure.
 
 == What is NetApp Workload Factory for Builders?
-NetApp Workload Factory for Builders is designed to streamline the way developers manage and interact with different versions of their software. Builders integrates seamlessly with Perforce Helix Core to provide instant clones of software versions, creating ready-to-use workspaces for development, QA, and CI/CD processes. 
+NetApp Workload Factory for Builders is designed to streamline the way developers manage and interact with different versions of their software. Builders works with Perforce Helix Core to instantly clone software versions and create workspaces for development, QA, and CI/CD. 
 
-With Builders, you can easily create a project and assign a volume that represents your software environment and its artifacts. As you update your software, you can take snapshots of the volume, capturing the state of your software at that moment. This means you can access any version of your software instantly without the need to resync with the version control system, saving valuable time and resources.
+With Builders, you can easily create a project and assign a volume that represents your software environment and its artifacts. As you update your software, you can take snapshots of the volume, capturing the state of your software at that moment. You can access any software version instantly without resyncing, saving time and resources.
 
-Using the snapshot and clone capabilities of NetApp ONTAP, Builders enhances your development workflow by enabling rapid access to multiple versions of your software, accelerating development cycles, and helping to reduce time to market.
+Using the snapshot and clone capabilities of NetApp ONTAP, Builders makes it faster to access different versions of your software, so you can develop and release updates more quickly.
 
 For more information about Workload Factory, refer to the link:https://docs.netapp.com/us-en/workload-setup-admin/workload-factory-overview.html[Workload Factory overview^].
 
@@ -34,11 +34,6 @@ NetApp Workload Factory for Builders offers the following features:
 == Projects and workspaces in Builders
 When you use Builders, you create a project and assign a volume that represents your software environment and its artifacts. Each time that you create a new version of the software, you need resync the volume data and create a project snapshot to mark the volume state as a known version. The project source volume might get rolling updates and have multiple snapshots to mark multiple versions. You can use each snapshot immediately as an instant clone, a dedicated or shared editable repository available to developers, QA or build processes. A clone in the context of a specific software version is a workspace.
  
-== Permission policies in Workload Factory
-Workload Factory offers flexible permission options. Gain immediate value at zero-trust without granting permissions using code snippets from the Codebox for use outside Workload Factory. Get incremental value with permission policies that build on top of one another starting with resource detection and analysis, then operations and remediation, and then deployment inside Workload Factory.  
-
-Learn more about link:https://docs.netapp.com/us-en/workload-setup-admin/permissions-reference.html[permissions in Workload Factory^].
-
 == Automation with Workload Factory Codebox
 Workload factory introduces built-in automation with the _Codebox_. The Codebox offers the following automation benefits: 
 
@@ -66,6 +61,6 @@ The following AWS regions aren't supported:
 * Top Secret Cloud
 
 == Getting help
-Amazon FSx for NetApp ONTAP is an AWS first-party solution. For questions or technical support issues associated with your FSx for ONTAP file system, infrastructure, or any solution using this service, use the Support Center in your AWS Management Console to open a support case with AWS. Select the “FSx for ONTAP” service and appropriate category. Provide the remaining information required to create your AWS support case.
+Amazon FSx for NetApp ONTAP is an AWS first-party solution. For support, use the Support Center in your AWS Management Console to open a case. Select "FSx for ONTAP" and the category, then provide the required information.
 
 For general questions about Workload Factory or Workload Factory applications and services, refer to link:get-help-builders.html[Get help for Builders for Workload Factory].

--- a/quick-start-builders.adoc
+++ b/quick-start-builders.adoc
@@ -1,7 +1,7 @@
 ---
 sidebar: sidebar
 permalink: quick-start-builders.html  
-keywords: requirements, Basic mode, Read-only mode, Read/Write mode 
+keywords: requirements, permissions
 summary: Databases has three different modes that have different requirements. 
 ---
 

--- a/quick-start-builders.adoc
+++ b/quick-start-builders.adoc
@@ -17,10 +17,14 @@ Get started creating a Builders project. Administrators and team leads can use B
 [role="quick-margin-para"]
 You'll need to https://docs.netapp.com/us-en/workload-setup-admin/sign-up-saas.html[set up an account with Workload Factory^] and log in using one of the https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
 
-.image:https://raw.githubusercontent.com/NetAppDocs/common/main/media/number-2.png[Two] Add AWS credentials and permissions to your account
+.image:https://raw.githubusercontent.com/NetAppDocs/common/main/media/number-2.png[Two] Add credentials and permissions
 
 [role="quick-margin-para"]
-You can use Workload Factory in _Basic_ mode without adding credentials to access your AWS account. Adding AWS credentials to Workload Factory in either _read-only_ or _read/write_ mode gives your Workload Factory account the permissions needed to create and manage FSx for ONTAP file systems, and to deploy and manage Builders projects.
+Choose the permission policies to meet your needs.
+
+If you choose not to grant permissions, you can start using Workload Factory for Builders to copy partially completed code samples.
+
+If you choose to grant permissions, you'll need to add credentials to an account manually that includes selecting workload capabilities, such as Builders and AI, and creating the IAM policies for the required permissions.
 
 [role="quick-margin-para"]
 https://docs.netapp.com/us-en/workload-setup-admin/add-credentials.html[Learn how to add credentials and permissions^].

--- a/quick-start-builders.adoc
+++ b/quick-start-builders.adoc
@@ -21,9 +21,9 @@ You'll need to https://docs.netapp.com/us-en/workload-setup-admin/sign-up-saas.h
 
 [role="quick-margin-para"]
 Choose the permission policies to meet your needs.
-
+[role="quick-margin-para"]
 If you choose not to grant permissions, you can start using Workload Factory for Builders to copy partially completed code samples.
-
+[role="quick-margin-para"]
 If you choose to grant permissions, you'll need to add credentials to an account manually that includes selecting workload capabilities, such as Builders and AI, and creating the IAM policies for the required permissions.
 
 [role="quick-margin-para"]

--- a/requirements-builders.adoc
+++ b/requirements-builders.adoc
@@ -15,10 +15,10 @@ Ensure that Workload Factory and AWS are set up properly before you begin using 
 Workload factory login and account::
 You'll need to https://docs.netapp.com/us-en/workload-setup-admin/sign-up-saas.html[set up an account with Workload Factory^] and log in using one of the https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
 
-AWS credentials and permissions::
-You need to add AWS credentials to Workload Factory with read/write permissions, which means you'll be using Workload Factory in _read/write_ mode for Builders.
+Credentials and permissions::
+Workload Factory for Builders supports the _Datastore deployment and connectivity_ permissions option. 
 
-_Basic_ mode and _read-only_ mode permissions are not supported at this time.
+_View, planning, and analysis_ permissions are not supported at this time.
 //+
 //When setting up your credentials, selecting permissions as shown below provides you with full access to manage FSx for ONTAP file systems and to deploy and manage Builders projects.
 //+

--- a/requirements-builders.adoc
+++ b/requirements-builders.adoc
@@ -10,20 +10,16 @@ summary: Ensure that Workload Factory and AWS are set up properly before you beg
 :imagesdir: ./media/
 
 [.lead]
-Ensure that Workload Factory and AWS are set up properly before you begin using NetApp Workload Factory for Builders. This includes having your AWS log in credentials, a deployed FSx for ONTAP file system, and more.
+Ensure that Workload Factory and AWS are set up properly before you use NetApp Workload Factory for Builders. This includes having your AWS log in credentials, a deployed FSx for ONTAP file system, and more.
 
 Workload factory login and account::
 You'll need to https://docs.netapp.com/us-en/workload-setup-admin/sign-up-saas.html[set up an account with Workload Factory^] and log in using one of the https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
 
 AWS credentials and permissions::
-Workload Factory for Builders supports the _Datastore deployment and connectivity_ permissions option. 
+You need to add AWS credentials to Workload Factory with read/write permissions, which means you'll be using Workload Factory in _read/write_ mode for Builders.
 
-_View, planning, and analysis_ permissions are not supported at this time.
-//+
-//When setting up your credentials, selecting permissions as shown below provides you with full access to manage FSx for ONTAP file systems and to deploy and manage Builders projects.
-//+
-//image:screenshot-ai-permissions.png[A screenshot showing the permissions setting for full management of AI resources.]
-//+
+_Basic_ mode and _read-only_ mode permissions are not supported at this time.
+
 https://docs.netapp.com/us-en/workload-setup-admin/add-credentials.html[Learn how to add AWS credentials to Workload Factory^]
 
 FSx for ONTAP file system::

--- a/requirements-builders.adoc
+++ b/requirements-builders.adoc
@@ -15,7 +15,7 @@ Ensure that Workload Factory and AWS are set up properly before you begin using 
 Workload factory login and account::
 You'll need to https://docs.netapp.com/us-en/workload-setup-admin/sign-up-saas.html[set up an account with Workload Factory^] and log in using one of the https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
 
-Credentials and permissions::
+AWS credentials and permissions::
 Workload Factory for Builders supports the _Datastore deployment and connectivity_ permissions option. 
 
 _View, planning, and analysis_ permissions are not supported at this time.


### PR DESCRIPTION
This pull request updates documentation for NetApp Workload Factory for Builders to clarify feature descriptions, simplify language, and update instructions related to AWS credentials and permissions. The changes focus on improving readability, removing outdated operational mode information, and aligning the documentation with current product requirements.

**Documentation simplification and feature clarification:**

* Updated the main feature description in `learn-builders.adoc` to use clearer, more concise language about how Builders works with Perforce Helix Core and NetApp ONTAP, emphasizing instant cloning and snapshot capabilities.
* Removed the section describing operational modes (basic, read-only, read/write) and the associated external link, reflecting that these modes are no longer relevant or supported.

**AWS credentials and permissions updates:**

* Revised instructions in `requirements-builders.adoc` to specify that only read/write permissions are supported for AWS credentials, and removed references to basic and read-only modes.
* Simplified the process for adding credentials and permissions in `quick-start-builders.adoc`, clarifying the options and updating guidance for users who do or do not grant permissions.
* Streamlined support instructions for Amazon FSx for NetApp ONTAP, making it easier for users to know how to get help.